### PR TITLE
fixed chat page receiving and duplicating server messages issue.

### DIFF
--- a/WPFClient/App.xaml.cs
+++ b/WPFClient/App.xaml.cs
@@ -18,7 +18,7 @@ namespace WPFClient
         protected override void OnStartup(StartupEventArgs e)
         {
             HubConnection connection = new HubConnectionBuilder()
-                .WithUrl(@"http://localhost:55740/chat")
+                .WithUrl(@"http://localhost:5000/chat")
                 .WithAutomaticReconnect()
                 .Build();
 

--- a/WPFClient/MainWindow.xaml.cs
+++ b/WPFClient/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace WPFClient
         public MainWindow()
         {
             InitializeComponent();
+            this.DataContext = this;
         }
     }
 }

--- a/WPFClient/Pages/ChatPage.xaml
+++ b/WPFClient/Pages/ChatPage.xaml
@@ -33,7 +33,8 @@
                 <RowDefinition Height="*"/>
             </Grid.RowDefinitions>
             <ListBox x:Name="MessagesListBox"
-                       ItemsSource="{Binding messages}"
+                       ItemsSource="{Binding Messages}"
+                       
                        Grid.Column="0" 
                        Grid.Row="0"
                        Grid.ColumnSpan="2"

--- a/WPFClient/Pages/ChatPage.xaml.cs
+++ b/WPFClient/Pages/ChatPage.xaml.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.AspNetCore.SignalR.Client;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -14,6 +16,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using System.Windows.Threading;
 
 namespace WPFClient
 {
@@ -25,26 +28,36 @@ namespace WPFClient
 
         BindingList<string> messages = new BindingList<string>();
 
+        ObservableCollection<string> messagesObservable = new ObservableCollection<string>();
+        public ObservableCollection<string> Messages { get; } = new ObservableCollection<string>();
+        
+        
+
         public ChatPage()
         {
-            
+            Messages.Add("TestMessage");
             InitializeComponent();
+            //DataContext = this;
+            MessagesListBox.ItemsSource = Messages;
+            new Thread(ReceiveChatMessage).Start();
+            
         }
 
         private void SubmitMessageButton_Click(object sender, RoutedEventArgs e)
         {
-
+            
             App._connection.InvokeCoreAsync("BroadcastUserMessage", args: new[] { MessageInputTextBox.Text });
+            
 
-            App._connection.On("ReceiveChatMessage", (string newMessage) =>
-            {
-                messages.Add(newMessage);
-            });
         }
 
-        public static void ReceiveChatMessage(string message)
+        public void ReceiveChatMessage()
         {
+            App._connection.On("ReceiveChatMessage", (string newMessage) =>
+            {
+                Messages.Add(newMessage);
 
+            });
         }
     }
 }


### PR DESCRIPTION
- Added ObservableCollection<string> property for MessagesListBox data.
- ReceiveChatMessage() runs on it's own thread now
- Solved duplicate messages by pulling the server invoke of "ReceiveChatMessage" method to ReceiveChatMessage()
- MessagesListBox ItemsSources declaration is now in the ChatPage constructor instead of XAML.
